### PR TITLE
Fix sorting in Elasticsearch Managment Console

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -36,7 +36,7 @@ def elasticsearch_status(request):
 
     disk_status = {
         disk['node']: disk for disk in
-        _get_es_meta(client, 'allocation', ['node', 'shards', 'disk.avail', 'disk.used', 'disk.percent'])
+        _get_es_meta(client, 'allocation', ['node', 'shards', 'disk.avail', 'disk.used', 'disk.percent'], {'bytes':"b"})
     }
 
     node_stats = {}
@@ -60,15 +60,15 @@ def elasticsearch_status(request):
     })
 
 
-def _get_es_meta(client, meta_type, fields, filter_rows=None):
+def _get_es_meta(client, meta_type, fields, options={}, filter_rows=None):
     return [{
         _to_camel_case(field.replace('.', '_')): o[field] for field in fields
-    } for o in getattr(client.cat, meta_type)(format="json", h=','.join(fields))
+    } for o in getattr(client.cat, meta_type)(**options, format="json", h=','.join(fields))
         if filter_rows is None or filter_rows(o)]
 
 def _get_es_indices(client):
     indices = _get_es_meta(
-        client, 'indices', ['index', 'docs.count', 'store.size', 'creation.date.string'],
+        client, 'indices', ['index', 'docs.count', 'store.size', 'creation.date.string'], {'bytes':"b"},
         filter_rows=lambda index: all(
             not index['index'].startswith(omit_prefix) for omit_prefix in ['.', 'index_operations_log']))
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -17,8 +17,8 @@ PROJECT_GUID = 'R0001_1kg'
 ES_CAT_ALLOCATION=[{
     'node': 'node-1',
     'shards': '113',
-    'disk.used': '67.2gb',
-    'disk.avail': '188.6gb',
+    'disk.used': '67200000000',
+    'disk.avail': '188600000000',
     'disk.percent': '26'
 },
     {'node': 'UNASSIGNED',
@@ -39,8 +39,8 @@ ES_CAT_NODES=[{
 EXPECTED_DISK_ALLOCATION = [{
     'node': 'node-1',
     'shards': '113',
-    'diskUsed': '67.2gb',
-    'diskAvail': '188.6gb',
+    'diskUsed': '67200000000',
+    'diskAvail': '188600000000',
     'diskPercent': '26',
     'heapPercent': '57',
 },
@@ -56,37 +56,37 @@ EXPECTED_NODE_STATS = [{'name': 'no-disk-node', 'heapPercent': '83'}]
 ES_CAT_INDICES = [{
     "index": "test_index",
     "docs.count": "122674997",
-    "store.size": "14.9gb",
+    "store.size": "14900000000",
     "creation.date.string": "2019-11-04T19:33:47.522Z"
 },
     {
         "index": "test_index_alias_1",
         "docs.count": "672312",
-        "store.size": "233.4mb",
+        "store.size": "233400000",
         "creation.date.string": "2019-10-03T19:53:53.846Z"
     },
     {
         "index": "test_index_alias_2",
         "docs.count": "672312",
-        "store.size": "233.4mb",
+        "store.size": "233400000",
         "creation.date.string": "2019-10-03T19:53:53.846Z"
     },
     {
         "index": "test_index_no_project",
         "docs.count": "672312",
-        "store.size": "233.4mb",
+        "store.size": "233400000",
         "creation.date.string": "2019-10-03T19:53:53.846Z"
     },
     {
         "index": "test_index_sv",
         "docs.count": "672312",
-        "store.size": "233.4mb",
+        "store.size": "233400000",
         "creation.date.string": "2019-10-03T19:53:53.846Z"
     },
     {
         "index": "test_index_sv_wgs",
         "docs.count": "672312",
-        "store.size": "233.4mb",
+        "store.size": "233400000",
         "creation.date.string": "2019-10-03T19:53:53.846Z"
     },
 ]
@@ -187,7 +187,7 @@ TEST_INDEX_EXPECTED_DICT = {
     "genomeVersion": "38",
     "sourceFilePath": "test_index_file_path",
     "docsCount": "122674997",
-    "storeSize": "14.9gb",
+    "storeSize": "14900000000",
     "creationDateString": "2019-11-04T19:33:47.522Z",
     "gencodeVersion": "25",
     "projects": [{'projectName': '1kg project n\xe5me with uni\xe7\xf8de', 'projectGuid': 'R0001_1kg'}]
@@ -199,7 +199,7 @@ TEST_SV_INDEX_EXPECTED_DICT = {
     "genomeVersion": "38",
     "sourceFilePath": "test_sv_index_path",
     "docsCount": "672312",
-    "storeSize": "233.4mb",
+    "storeSize": "233400000",
     "creationDateString": "2019-10-03T19:53:53.846Z",
     "gencodeVersion": "29",
     "datasetType": "SV",
@@ -212,7 +212,7 @@ TEST_INDEX_NO_PROJECT_EXPECTED_DICT = {
     "genomeVersion": "37",
     "sourceFilePath": "test_index_no_project_path",
     "docsCount": "672312",
-    "storeSize": "233.4mb",
+    "storeSize": "233400000",
     "creationDateString": "2019-10-03T19:53:53.846Z",
     "datasetType": "VARIANTS",
     "gencodeVersion": "19",
@@ -289,11 +289,11 @@ class DataManagerAPITest(AuthenticationTestCase):
         self.check_data_manager_login(url)
 
         urllib3_responses.add_json(
-            '/_cat/allocation?format=json&h=node,shards,disk.avail,disk.used,disk.percent', ES_CAT_ALLOCATION)
+            '/_cat/allocation?bytes=b&format=json&h=node,shards,disk.avail,disk.used,disk.percent', ES_CAT_ALLOCATION)
         urllib3_responses.add_json(
             '/_cat/nodes?format=json&h=name,heap.percent', ES_CAT_NODES)
         urllib3_responses.add_json(
-           '/_cat/indices?format=json&h=index,docs.count,store.size,creation.date.string', ES_CAT_INDICES)
+           '/_cat/indices?bytes=b&format=json&h=index,docs.count,store.size,creation.date.string', ES_CAT_INDICES)
         urllib3_responses.add_json('/_cat/aliases?format=json&h=alias,index', ES_CAT_ALIAS)
         urllib3_responses.add_json('/_all/_mapping', ES_INDEX_MAPPING)
 
@@ -324,7 +324,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         self.assertEqual(len(urllib3_responses.calls), 0)
 
         urllib3_responses.add_json(
-            '/_cat/indices?format=json&h=index,docs.count,store.size,creation.date.string', ES_CAT_INDICES)
+            '/_cat/indices?bytes=b&format=json&h=index,docs.count,store.size,creation.date.string', ES_CAT_INDICES)
         urllib3_responses.add_json('/_cat/aliases?format=json&h=alias,index', ES_CAT_ALIAS)
         urllib3_responses.add_json('/_all/_mapping', ES_INDEX_MAPPING)
         urllib3_responses.add(urllib3_responses.DELETE, '/unused_index')

--- a/ui/shared/utils/stringUtils.js
+++ b/ui/shared/utils/stringUtils.js
@@ -19,3 +19,13 @@ export const toUniqueCsvString = (...csvStrs) => {
 
   return [...new Set(splitted)].join(',')
 }
+
+export const formatBytes = (bytes) => {
+  if (bytes === 0) return '0 Bytes'
+  if (!bytes) return null
+  const k = 1024
+  const dm = 2
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / (k ** i)).toFixed(dm))}\xa0${sizes[i]}`
+}


### PR DESCRIPTION
This fixes 3 things in the Elasticsearch Management Console:

1. Simple numbers (shards) are parsed so they sort properly
2. Disk sizes are stored as bytes to be sortable, and then formatted to be human readble
3. The more complex Projects array of objects is sorted on number of projects, then project name.

**Item 1.** Has been done in the front end, because Elasticsearch passes back strings, and I think that it would be more consistent if the logic was kept in one place, e.g. parsing ints in the front end like parsing dates. And using the numbers to sort is a display issue, not a problem with the data.

**Item 2.** I've changed data_manager_api.py to provide a `'bytes'="b"` option to the elasticsearch query, where it is needed.

[Is this a python convention we should be following? Using single quotes and double quotes like this?](https://www.askpython.com/python/string/difference-between-single-and-double-quotes-in-python)

**Item 3.** [On line 84 of ElasticsearchStatus.jsx](https://github.com/bioinfomethods/seqr/compare/mcri/develop...bioinfomethods:mcri/fix-elasticsearch-management-sort-105?diff=split#diff-751a596e90d300859e1f98555eb334a421345296e47b3a1b2087acc121881a78R84), I add an artificial sorting property, which is then used to sort the projects.

This management console is not user facing so low priority. I am using these improvements as examples that could be used on the other tables in seqr, e.g. the Projects table on the home page has an unsortable "Samples" column.